### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -12,7 +12,7 @@
     pod 'RetainCC'
     ```
     
-3. Run `pod install` in your XCode project directory.
+3. Run `pod install` in your Xcode project directory.
 
 4. Then import the library in AppDelegate
 


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
